### PR TITLE
Add custom database create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Docker build
         # Test that the container can be built successfully
-        run: docker build . -t satellite
+        run: docker build . -t satellite --build-arg TAG=${{ github.head_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,7 @@ jobs:
           pytest
 
       - name: Docker build
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         # Test that the container can be built successfully
-        run: docker build . -t satellite --build-arg TAG=${{ github.head_ref }}
+        run: docker build . -t satellite --build-arg TAG="$HEAD_REF"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM postgres:15.0-bullseye
 # User definable arguments
 ARG POSTGRES_USER=postgres
 ARG POSTGRES_PASSWORD=postgres
+ARG DATABASE_NAME=emap
 ARG N_TABLE_ROWS=4
 ARG INSERT_RATE=0.3
 ARG UPDATE_RATE=0.2
@@ -48,12 +49,13 @@ RUN if [ "$TAG" != "" ] ; then \
 
 WORKDIR /Satellite
 RUN pip install --no-cache-dir . && \
-    satellite print-create-command > /docker-entrypoint-initdb.d/create.sql
+    satellite print-db-create-command > /docker-entrypoint-initdb.d/create.sql && \
+    satellite print-create-command >> /docker-entrypoint-initdb.d/create.sql
 
 # Export the variables to the runtime of the container
 ENV POSTGRES_USER ${POSTGRES_USER}
 ENV POSTGRES_PASSWORD ${POSTGRES_PASSWORD}
-ENV UPDATE_RATE ${UPDATE_RATE}
+ENV DATABASE_NAME ${DATABASE_NAME}
 ENV INFORMDB_BRANCH_NAME ${INFORMDB_BRANCH_NAME}
 ENV STAR_SCHEMA_NAME ${STAR_SCHEMA_NAME}
 ENV FAKER_SEED ${FAKER_SEED}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "satellite"
-version = "0.0.8"
+version = "0.1.0"
 authors = [
   { name="Tom Young" },
 ]

--- a/satellite/_schema.py
+++ b/satellite/_schema.py
@@ -26,6 +26,7 @@ class DatabaseSchema:
         self,
         name: str,
         tables: Tables,
+        database_name: str,
         host: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
@@ -33,12 +34,17 @@ class DatabaseSchema:
         self.tables = tables
         self._name = name
         self._host = host
+        self._database_name = database_name
         self._username = username
         self._password = password
 
         self._cursor: Any = None
         self._connection: Any = None
         self._try_and_connect()
+
+    @property
+    def database_name(self) -> str:
+        return self._database_name
 
     @property
     def schema_name(self) -> str:
@@ -53,6 +59,7 @@ class DatabaseSchema:
                 "a defined username for authorisation"
             )
         return (
+            rf"\connect {self.database_name}" + "\n"
             f"DROP SCHEMA IF EXISTS {self.schema_name} CASCADE;\n"
             f"CREATE SCHEMA {self.schema_name} "
             f"AUTHORIZATION {self._username};\n"
@@ -73,7 +80,7 @@ class DatabaseSchema:
     def _try_and_connect(self) -> None:
         try:
             self._connection = psycopg2.connect(
-                f"dbname=postgres user={self._username} "
+                f"dbname={self._database_name} user={self._username} "
                 f"password={self._password} host={self._host}"
             )
             self._cursor = self._connection.cursor()

--- a/satellite/_settings.py
+++ b/satellite/_settings.py
@@ -22,6 +22,7 @@ _default_values = {
     "INFORMDB_BRANCH_NAME": "master",
     "POSTGRES_HOST": "localhost",
     "N_TABLE_ROWS": "0",
+    "DATABASE_NAME": "emap",
 }
 
 

--- a/satellite/_tables.py
+++ b/satellite/_tables.py
@@ -76,10 +76,10 @@ class _TableChunk:
                 self[column] = [row[column.name] for row in rows]
 
     def add_fake_data(self, skip_foreign_keys: bool = False) -> None:
-        logger.info(f"Adding fake data to {self.name}")
+        logger.debug(f"Adding fake data to {self.name}")
 
         for column in self.data_columns if skip_foreign_keys else self.non_pk_columns:
-            logger.info(f"Creating {self.n_rows} row(s) of data to {column.name}")
+            logger.debug(f"Creating {self.n_rows} row(s) of data to {column.name}")
 
             function = column.faker_method
 

--- a/satellite/main.py
+++ b/satellite/main.py
@@ -23,6 +23,7 @@ from satellite._utils import call_every_n_seconds
 star = DatabaseSchema(
     name=EnvVar("STAR_SCHEMA_NAME").or_default(),
     host=EnvVar("POSTGRES_HOST").or_default(),
+    database_name=EnvVar("DATABASE_NAME").or_default(),
     username=EnvVar("POSTGRES_USER").unwrap(),
     password=EnvVar("POSTGRES_PASSWORD").unwrap(),
     tables=Tables.from_repo(
@@ -35,6 +36,11 @@ star = DatabaseSchema(
 @click.group()
 def cli() -> None:
     """Satellite command line interface"""
+
+
+@cli.command()
+def print_db_create_command() -> None:
+    print(f"CREATE DATABASE {star.database_name};")
 
 
 @cli.command()
@@ -98,7 +104,7 @@ def continuously_update() -> None:
     def update() -> None:
         star.update_num_rows_in_tables()
         for table in star.tables:
-            logger.info(f"Updating row from {table.name}")
+            logger.debug(f"Updating row from {table.name}")
             star.update(table.randomised_existing_row())
 
     call_every_n_seconds(update, num_seconds=time_delay)
@@ -121,7 +127,7 @@ def continuously_delete() -> None:
     def delete() -> None:
         star.update_num_rows_in_tables()
         for table in star.tables:
-            logger.info(f"Deleting row from {table.name}")
+            logger.debug(f"Deleting row from {table.name}")
             star.delete(table.random_existing_row())
 
     call_every_n_seconds(delete, num_seconds=time_delay)


### PR DESCRIPTION
# Resolves #27 #26 

Throwing the schema into the default postgres database within the instance is not best practice. This PR adds a `print-db-create-command` CLI command and uses it in the example docker container

***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] An issue has been created for any pending work
* [x] Test pass
* [x] Documentation has been updated
* [x] Version has been bumped if required
